### PR TITLE
#88: fix para que todos los 'titles' de pagina sean iguales

### DIFF
--- a/preciosa/templates/base.html
+++ b/preciosa/templates/base.html
@@ -16,7 +16,7 @@
 
 
 
-    <title>{% block head_title_base %}{% if SITE_NAME %}{{ SITE_NAME }} | {% endif %}{% block head_title %}{% endblock %}{% endblock %}</title>
+    <title>{% block head_title_base %}{% if SITE_NAME %}{{ SITE_NAME }}{% endif %}{% endblock %}</title>
 
 
 


### PR DESCRIPTION
Fix para que todos los 'titles' de pagina sean iguales (menos el de rss). Usa el generador de titulos del template base sin mas agregados.

https://github.com/mgaitan/preciosa/issues/88
