### PR TITLE
fixes #59 form para cargar cadenas y sucursales

### DIFF
--- a/preciosa/precios/models.py
+++ b/preciosa/precios/models.py
@@ -28,6 +28,10 @@ class Categoria(MP_Node):
             return unicode(self.get_parent()) + " > " + self.nombre
         return self.nombre
 
+    class Meta:
+        verbose_name = u"categoria"
+        verbose_name_plural = u"categorias"
+
     @models.permalink
     def get_absolute_url(self):
         return ('lista_productos', (self.id, slugify(self.nombre)), {})
@@ -69,6 +73,10 @@ class Producto(models.Model):
     def __unicode__(self):
         return self.descripcion
 
+    class Meta:
+        verbose_name = u"producto"
+        verbose_name_plural = u"productos"
+
     @models.permalink
     def get_absolute_url(self):
         return ('detalle_producto',
@@ -102,6 +110,8 @@ class Marca(models.Model):
 
     class Meta:
         unique_together = (('nombre', 'fabricante'))
+        verbose_name = u"marca"
+        verbose_name_plural = u"marcas"
 
 
 class AbstractEmpresa(models.Model):
@@ -124,6 +134,10 @@ class Cadena(AbstractEmpresa):
 
     cadena_madre = models.ForeignKey('self', null=True, blank=True,
                                      help_text="Jumbo y Vea son de Cencosud")
+
+    class Meta:
+        verbose_name = u"cadena de supermercados"
+        verbose_name_plural = u"cadenas de supermercados"
 
 
 class EmpresaFabricante(AbstractEmpresa):
@@ -168,6 +182,8 @@ class Sucursal(models.Model):
 
     class Meta:
         unique_together = (('direccion', 'ciudad'))
+        verbose_name = u"sucursal"
+        verbose_name_plural = u"sucursales"
 
 
 class PrecioManager(models.Manager):
@@ -199,6 +215,10 @@ class Precio(TimeStampedModel):
     def __unicode__(self):
         return u'%s: $ %s' % (self.producto, self.precio)
 
+    class Meta:
+        verbose_name = u"precio"
+        verbose_name_plural = u"precios"
+
 
 class PrecioEnAcuerdo(models.Model):
     producto = models.ForeignKey('Producto')
@@ -207,3 +227,7 @@ class PrecioEnAcuerdo(models.Model):
 
     precio_norte = models.DecimalField(max_digits=5, decimal_places=2)
     precio_sur = models.DecimalField(max_digits=5, decimal_places=2)
+
+    class Meta:
+        verbose_name = u"precio en acuerdo"
+        verbose_name_plural = u"precios en acuerdo"

--- a/preciosa/precios/models.py
+++ b/preciosa/precios/models.py
@@ -3,9 +3,9 @@ from datetime import datetime, timedelta
 from django.utils import timezone
 from django.contrib.gis.db import models
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.utils.text import slugify
 from django.db.models import Min
-
 from model_utils import Choices
 from model_utils.fields import MonitorField
 from model_utils.models import TimeStampedModel
@@ -175,7 +175,7 @@ class Sucursal(models.Model):
 
     def clean(self):
         if not self.cadena and not self.nombre:
-            raise models.ValidationError('Indique la cadena o el nombre del comercio')
+            raise ValidationError('Indique la cadena o el nombre del comercio')
 
     def __unicode__(self):
         return u"%s (%s)" % (self.cadena or self.nombre, self.direccion)

--- a/preciosa/templates/voluntarios/alta_cadena_sucursal.html
+++ b/preciosa/templates/voluntarios/alta_cadena_sucursal.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "voluntarios/base.html" %}
 {% load bootstrap %}
 {% load humanize %}
 {% load cropping thumbnail %}

--- a/preciosa/templates/voluntarios/alta_cadena_sucursal.html
+++ b/preciosa/templates/voluntarios/alta_cadena_sucursal.html
@@ -1,0 +1,126 @@
+{% extends "base.html" %}
+{% load bootstrap %}
+{% load humanize %}
+{% load cropping thumbnail %}
+
+{# pongo los mensajes más cerca del formulario #}
+{% block messages %}{% endblock  %}
+{% block body %}
+    <h1 class="page-header">Agregar sucursal</h1>
+     <p class="lead">
+        Conocer todas las sucursales de las diferentes cadenas de supermercados
+        nos permitirá, en un futuro, hacer estadisticas para comprar mejor.
+        Podremos saber, por ejemplo, <strong> ¿Cuál sucursal de mi zona a
+          remarcado en promedio más los precios?</strong>.
+    </p>
+    <p class="lead">
+        Para hacer esto, primero necesitamos conocer todas las sucursales. Ya conocemos varias, pero seguro vos conocés más.
+    </p>
+    {% include "_messages.html" %}
+
+<div class="row">
+    <div class="col-lg-5">
+        <h3>Agregar una nueva sucursal</h3>
+        <form method="post" action="." enctype="multipart/form-data">
+            {% csrf_token %}
+            {{ form_sucursal|bootstrap }}
+            <input class="btn btn-primary btn-lg" type="submit" name="btn_form_sucursal" value="Agregar esta sucursal" />
+        </form>
+    </div>
+    <div class="col-lg-3">
+        <div class="panel panel-info">
+            <div class="panel-heading">¿No está la cadena de supermercados que buscás?</div>
+            <div class="panel-body">
+                 <form method="post" action="." enctype="multipart/form-data" >
+                     {% csrf_token %}
+                     {{ form_cadena|bootstrap }}
+                     <input class="btn btn-primary" type="submit" name="btn_form_cadena" value="Agregar" />
+                 </form>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-4">
+        <div class="chat-panel panel panel-default">
+            <div class="panel-heading">
+                <i class="fa fa-comments fa-fw"></i>Votar actividad recientemente
+            </div>
+            <div class="panel-body">
+                <ul class="chat">
+                    {% for item in creados %}
+                    <li class="left clearfix">
+                    <span class="chat-img pull-left">
+                        <p>
+                        <button title="Parece correcto" class="btn btn-success btn-circle vot_yes" data-pk="{{ item.id }}" type="button">
+                            <i class="fa fa-check"></i>
+                        </button>
+                        </p>
+                        <p>
+                        <button title="Parece incorrecto" class="btn btn-danger btn-circle vot_no" data-pk="{{ item.id }}" type="button">
+                            <i class="fa fa-times"></i>
+                        </button>
+                        </p>
+                    </span>
+                    <div class="chat-body clearfix">
+                        <div class="header">
+                            <strong class="primary-font">{{ item.user.username }} </strong>
+                            <small class="pull-right text-muted">
+                                <i class="fa fa-clock-o fa-fw"></i> {{ item.created|naturaltime }}
+                            </small>
+                        </div>
+                        <p>
+                        {% if item.sucursal %}
+                            creó la sucursal <strong>{{ item.sucursal.nombre }}</strong>
+                            perteneciente a <strong>{{ item.sucursal.cadena.nombre }}</strong>
+                        {% else %}
+                            creó la cadena de supermercados
+                            <strong>{{ item.cadena.nombre }}</strong>
+                        {% endif %}
+                        </p>
+                    </div>
+                    </li>
+                    {% endfor %}
+                </ul>
+           </div><!-- /.panel-body -->
+        </div>
+    </div>
+</div>
+
+{% endblock body %}
+{% block extra_footer %}
+    <script type="text/javascript">
+
+    $(function(){
+    // Make a javascript Autocomplete object and set it up
+    var autocomplete2 = $('#id_nombre').yourlabsAutocomplete({
+        url: '{% url "autocomplete_nombre_sucursal" %}',
+    });
+
+    $('button.vot_yes').on('click', function(){
+        var $but = $(this);
+        var pk = $but.data('pk');
+        $.post('./voto/' + pk + '/',
+               {'voto': true, 'model': 'voluntarios.SucursalCadenaCreada'},
+               function(response){
+                   if (response.result){
+                       $but.parents('.left').fadeOut();
+                   }
+               }
+        );
+    });
+
+    $('button.vot_no').on('click', function(){
+        var $but = $(this);
+        var pk = $but.data('pk');
+        $.post('./voto/' + pk + '/', {'voto': false, 'model':
+          'voluntarios.SucursalCadenaCreada'}, function(response){
+            if (response.result){
+                $but.parents('.left').fadeOut();
+            }
+        });
+    });
+
+
+    });
+
+    </script>
+{% endblock extra_footer %}

--- a/preciosa/templates/voluntarios/alta_marca.html
+++ b/preciosa/templates/voluntarios/alta_marca.html
@@ -119,7 +119,8 @@
     $('button.vot_yes').on('click', function(){
         var $but = $(this);
         var pk = $but.data('pk');
-        $.post('./voto/' + pk + '/', {'voto': true}, function(response){
+        $.post('./voto/' + pk + '/', {'voto': true, 'model':
+          'voluntarios.MarcaEmpresaCreada'}, function(response){
             if (response.result){
                 $but.parents('.left').fadeOut();
             }
@@ -129,7 +130,8 @@
     $('button.vot_no').on('click', function(){
         var $but = $(this);
         var pk = $but.data('pk');
-        $.post('./voto/' + pk + '/', {'voto': false}, function(response){
+        $.post('./voto/' + pk + '/', {'voto': false, 'model':
+          'voluntarios.MarcaEmpresaCreada'}, function(response){
             if (response.result){
                 $but.parents('.left').fadeOut();
             }

--- a/preciosa/templates/voluntarios/autocomplete_nombre_sucursal.html
+++ b/preciosa/templates/voluntarios/autocomplete_nombre_sucursal.html
@@ -1,0 +1,10 @@
+{% load url from future %}
+
+{% for sucursal in sucursales %}
+<div class="choice">
+    {{ sucursal.nombre  }}  
+    {% if sucursal.cadena %}
+        ({{ sucursal.cadena.nombre }})
+    {% endif %}
+</div>
+{% endfor %}

--- a/preciosa/templates/voluntarios/dashboard.html
+++ b/preciosa/templates/voluntarios/dashboard.html
@@ -77,6 +77,26 @@
             </div>
 
         </div>
+
+        <div class="col-lg-6">
+            <div class="panel panel-danger">
+                <div class="panel-heading">
+                    <h3 class="panel-title"><i class="fa fa-plus-square"></i> Agregar sucursales</h3>
+                </div>
+                <!-- /.panel-heading -->
+                <div class="panel-body">
+                    <p>
+                        También es necesario conocer todas las sucursales
+                        de las diferentes cadenas de supermercados que hay
+                        en el país.
+                    </p>
+                    <a class="btn btn-primary btn-lg btn-block btn-danger" href="{% url 'alta_cadena_sucursal' %}">Agregar nuevas sucursales</a>
+
+                </div>    <!-- /.panel-body -->
+            </div>
+        </div>
+        </div> <!-- /.row -->
+        <div class="row">
         <div class="col-lg-6">
               <div class="panel panel-primary">
                     <div class="panel-heading">
@@ -151,29 +171,6 @@
             </div>
 
 
-        </div>
-
-
-        <div class="col-lg-6">
-            <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h3 class="panel-title">Agregar sucursales</h3>
-                    </div>
-                    <!-- /.panel-heading -->
-                    <div class="panel-body">
-                        <p>
-                            También es necesario conocer todas las sucursales
-                            de las diferentes cadenas de supermercados que hay
-                            en el país.
-                        </p>
-                    <a class="btn btn-primary btn-lg btn-block" href="{% url 'alta_cadena_sucursal' %}">Agregar nuevas sucursales</a>
-
-                    </div>
-                    <!-- /.panel-body -->
-            </div>
-
-        </div>
-        <div class="col-lg-6">
         </div>
 
     </div>  <!-- /.row -->

--- a/preciosa/templates/voluntarios/dashboard.html
+++ b/preciosa/templates/voluntarios/dashboard.html
@@ -153,9 +153,30 @@
 
         </div>
 
+
+        <div class="col-lg-6">
+            <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Agregar sucursales</h3>
+                    </div>
+                    <!-- /.panel-heading -->
+                    <div class="panel-body">
+                        <p>
+                            También es necesario conocer todas las sucursales
+                            de las diferentes cadenas de supermercados que hay
+                            en el país.
+                        </p>
+                    <a class="btn btn-primary btn-lg btn-block" href="{% url 'alta_cadena_sucursal' %}">Agregar nuevas sucursales</a>
+
+                    </div>
+                    <!-- /.panel-body -->
+            </div>
+
+        </div>
+        <div class="col-lg-6">
+        </div>
+
     </div>  <!-- /.row -->
-
-
 
     {% else %}
 

--- a/preciosa/voluntarios/migrations/0003_auto__add_sucursalcadenacreada__add_votosucursalcadenacreada.py
+++ b/preciosa/voluntarios/migrations/0003_auto__add_sucursalcadenacreada__add_votosucursalcadenacreada.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'SucursalCadenaCreada'
+        db.create_table(u'voluntarios_sucursalcadenacreada', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('created', self.gf('model_utils.fields.AutoCreatedField')(default=datetime.datetime.now)),
+            ('modified', self.gf('model_utils.fields.AutoLastModifiedField')(default=datetime.datetime.now)),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'])),
+            ('sucursal', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['precios.Sucursal'], null=True)),
+            ('cadena', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['precios.Cadena'], null=True)),
+        ))
+        db.send_create_signal(u'voluntarios', ['SucursalCadenaCreada'])
+
+        # Adding model 'VotoSucursalCadenaCreada'
+        db.create_table(u'voluntarios_votosucursalcadenacreada', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('created', self.gf('model_utils.fields.AutoCreatedField')(default=datetime.datetime.now)),
+            ('modified', self.gf('model_utils.fields.AutoLastModifiedField')(default=datetime.datetime.now)),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'])),
+            ('voto', self.gf('django.db.models.fields.IntegerField')()),
+            ('item', self.gf('django.db.models.fields.related.ForeignKey')(related_name='votos', to=orm['voluntarios.SucursalCadenaCreada'])),
+        ))
+        db.send_create_signal(u'voluntarios', ['VotoSucursalCadenaCreada'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'SucursalCadenaCreada'
+        db.delete_table(u'voluntarios_sucursalcadenacreada')
+
+        # Deleting model 'VotoSucursalCadenaCreada'
+        db.delete_table(u'voluntarios_votosucursalcadenacreada')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'cities_light.city': {
+            'Meta': {'ordering': "['name']", 'unique_together': "(('region', 'name'),)", 'object_name': 'City'},
+            'alternate_names': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cities_light.Country']"}),
+            'display_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'feature_code': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'geoname_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latitude': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '8', 'decimal_places': '5', 'blank': 'True'}),
+            'longitude': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '8', 'decimal_places': '5', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'name_ascii': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '200', 'blank': 'True'}),
+            'population': ('django.db.models.fields.BigIntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'region': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cities_light.Region']", 'null': 'True', 'blank': 'True'}),
+            'search_names': ('cities_light.models.ToSearchTextField', [], {'default': "''", 'max_length': '4000', 'db_index': 'True', 'blank': 'True'}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique_with': '()', 'max_length': '50', 'populate_from': "'name_ascii'"})
+        },
+        u'cities_light.country': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Country'},
+            'alternate_names': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'code2': ('django.db.models.fields.CharField', [], {'max_length': '2', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'code3': ('django.db.models.fields.CharField', [], {'max_length': '3', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'continent': ('django.db.models.fields.CharField', [], {'max_length': '2', 'db_index': 'True'}),
+            'geoname_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            'name_ascii': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '200', 'blank': 'True'}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique_with': '()', 'max_length': '50', 'populate_from': "'name_ascii'"}),
+            'tld': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '5', 'blank': 'True'})
+        },
+        u'cities_light.region': {
+            'Meta': {'ordering': "['name']", 'unique_together': "(('country', 'name'),)", 'object_name': 'Region'},
+            'alternate_names': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cities_light.Country']"}),
+            'display_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'geoname_code': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'geoname_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'name_ascii': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '200', 'blank': 'True'}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique_with': '()', 'max_length': '50', 'populate_from': "'name_ascii'"})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'precios.cadena': {
+            'Meta': {'object_name': 'Cadena'},
+            'cadena_madre': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['precios.Cadena']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': (u'django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'logo_changed': ('model_utils.fields.MonitorField', [], {'default': 'datetime.datetime.now', u'monitor': "'logo'"}),
+            'logo_cropped': (u'django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'nombre': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'})
+        },
+        u'precios.categoria': {
+            'Meta': {'object_name': 'Categoria'},
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'nombre': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'numchild': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        u'precios.empresafabricante': {
+            'Meta': {'object_name': 'EmpresaFabricante'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': (u'django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'logo_changed': ('model_utils.fields.MonitorField', [], {'default': 'datetime.datetime.now', u'monitor': "'logo'"}),
+            'logo_cropped': (u'django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'nombre': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'})
+        },
+        u'precios.marca': {
+            'Meta': {'unique_together': "(('nombre', 'fabricante'),)", 'object_name': 'Marca'},
+            'fabricante': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['precios.EmpresaFabricante']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': (u'django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'logo_changed': ('model_utils.fields.MonitorField', [], {'default': 'datetime.datetime.now', u'monitor': "'logo'"}),
+            'logo_cropped': (u'django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'nombre': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'})
+        },
+        u'precios.sucursal': {
+            'Meta': {'unique_together': "(('direccion', 'ciudad'),)", 'object_name': 'Sucursal'},
+            'cadena': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'sucursales'", 'null': 'True', 'to': u"orm['precios.Cadena']"}),
+            'ciudad': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cities_light.City']"}),
+            'cp': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'direccion': ('django.db.models.fields.CharField', [], {'max_length': '120'}),
+            'horarios': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'nombre': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'telefono': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'ubicacion': ('django.contrib.gis.db.models.fields.PointField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'voluntarios.mapacategoria': {
+            'Meta': {'unique_together': "(('user', 'origen'),)", 'object_name': 'MapaCategoria'},
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'destino': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'mapeo_destino'", 'to': u"orm['precios.Categoria']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'origen': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'mapeo_origen'", 'to': u"orm['precios.Categoria']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        },
+        u'voluntarios.marcaempresacreada': {
+            'Meta': {'object_name': 'MarcaEmpresaCreada'},
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            'empresa': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['precios.EmpresaFabricante']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'marca': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['precios.Marca']", 'null': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        },
+        u'voluntarios.sucursalcadenacreada': {
+            'Meta': {'object_name': 'SucursalCadenaCreada'},
+            'cadena': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['precios.Cadena']", 'null': 'True'}),
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'sucursal': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['precios.Sucursal']", 'null': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        },
+        u'voluntarios.votomarcaempresacreada': {
+            'Meta': {'object_name': 'VotoMarcaEmpresaCreada'},
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'item': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'votos'", 'to': u"orm['voluntarios.MarcaEmpresaCreada']"}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'voto': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'voluntarios.votosucursalcadenacreada': {
+            'Meta': {'object_name': 'VotoSucursalCadenaCreada'},
+            'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'item': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'votos'", 'to': u"orm['voluntarios.SucursalCadenaCreada']"}),
+            'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'voto': ('django.db.models.fields.IntegerField', [], {})
+        }
+    }
+
+    complete_apps = ['voluntarios']

--- a/preciosa/voluntarios/migrations/0004_auto__add_sucursalcadenacreada__add_votosucursalcadenacreada.py
+++ b/preciosa/voluntarios/migrations/0004_auto__add_sucursalcadenacreada__add_votosucursalcadenacreada.py
@@ -166,11 +166,13 @@ class Migration(SchemaMigration):
         },
         u'voluntarios.mapacategoria': {
             'Meta': {'unique_together': "(('user', 'origen'),)", 'object_name': 'MapaCategoria'},
+            'comentario': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
             'created': ('model_utils.fields.AutoCreatedField', [], {'default': 'datetime.datetime.now'}),
             'destino': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'mapeo_destino'", 'to': u"orm['precios.Categoria']"}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'modified': ('model_utils.fields.AutoLastModifiedField', [], {'default': 'datetime.datetime.now'}),
             'origen': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'mapeo_origen'", 'to': u"orm['precios.Categoria']"}),
+            'separar': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
         },
         u'voluntarios.marcaempresacreada': {

--- a/preciosa/voluntarios/mixins.py
+++ b/preciosa/voluntarios/mixins.py
@@ -1,0 +1,82 @@
+# coding=utf-8
+import re
+
+from django import forms
+from django.contrib.auth.decorators import login_required
+from django.utils.decorators import method_decorator
+
+
+class AuthenticatedViewMixin(object):
+    """Mixin para vistas que requieren autenticación"""
+
+    @method_decorator(login_required)
+    def dispatch(self, *args, **kwargs):
+        return super(AuthenticatedViewMixin, self).dispatch(*args, **kwargs)
+
+
+class CleanNombreMixin(object):
+
+    max_cantidad_palabras = 3
+    max_largo = 20
+    max_palabras_con_numeros = 1
+    model_related = None
+
+    def clean_nombre(self):
+        """algunos controles sobre el input del usuario,
+        para protegernos todo lo posible de info basura
+
+        """
+        kind = self.model_related._meta.verbose_name
+
+        def count_int(palabras):
+            # why the hell no a regex? because they sucks
+            c = 0
+            for p in palabras:
+                try:
+                    int(p)
+                    c += 1
+                except ValueError:
+                    pass
+            return c
+
+        def capitalizar(palabras):
+            """('la', 'morenita') ->  La Morenita
+               ('0', 'de', 'ORO') -> 9 de Oro
+            """
+            result = []
+            for i, palabra in enumerate(palabras):
+                if i == 0 or len(palabra) > 2:
+                    result.append(palabra.capitalize())
+                else:
+                    result.append(palabra)
+            return ' '.join(result)
+
+        data = self.cleaned_data
+        nombre = data['nombre'].lower().strip()
+        palabras = nombre.split()
+
+        # marca muy larga?
+        if len(nombre) > self.max_largo:
+            raise forms.ValidationError(u"¿No es un nombre de %s demasiado largo? "
+                                        u"Envianos un mensaje si estamos equivocados" % kind)    # noqa
+
+        # si tiene mas de 3 palabras, es sospechoso
+        # '9 de Oro'
+        if len(palabras) > self.max_cantidad_palabras:
+            raise forms.ValidationError(u"¿No son demasiadas palabras para una %s? "
+                                        u"Envianos un mensaje si estamos equivocados" % kind)    # noqa
+
+        # si las palabras no son palabras o numeros, también.
+        if not all(map(lambda a: re.search(r'^[a-z0-9áéíóúüñ]+$', a.encode('utf8'), flags=re.UNICODE), palabras)):
+            raise forms.ValidationError(u"No parece una %s ¿Estás usando algún caracter extraño? "  # noqa
+                                        u"Envianos un mensaje si estamos equivocados" % kind)     # noqa
+        #si hay más de una palabra que sea de numeros, also
+        if count_int(palabras) > self.max_palabras_con_numeros:
+            raise forms.ValidationError(u"¿No demasiados números en esta %s? "
+                                        u"Envianos un mensaje si estamos equivocados" % kind)     # noqa
+        nombre = capitalizar(palabras)
+        # Model = Marca if kind == 'marca' else EmpresaFabricante
+        if self.model_related.objects.filter(nombre__iexact=nombre).exists():
+            raise forms.ValidationError(u"¿Seguro que esta %s no existe ya? "
+                                        u"Envianos un mensaje si estamos equivocados" % kind)    # noqa
+        return nombre

--- a/preciosa/voluntarios/models.py
+++ b/preciosa/voluntarios/models.py
@@ -13,7 +13,8 @@ from django.db import models
 from django.contrib.auth.models import User
 from model_utils.models import TimeStampedModel
 
-from preciosa.precios.models import Categoria, Marca, EmpresaFabricante
+from preciosa.precios.models import (Cadena, Categoria, Marca,
+                                    EmpresaFabricante, Sucursal)
 from collections import Counter
 
 
@@ -62,16 +63,42 @@ class MapaCategoria(TimeStampedModel):
         return Categoria.por_clasificar().exclude(id__in=ya_hechas)
 
 
-class MarcaEmpresaCreada(TimeStampedModel):
+class EntidadCreadaVoluntario(TimeStampedModel):
+    user = models.ForeignKey(User, editable=False)
+
+    class Meta:
+        abstract = True
+
+
+class VotoVoluntario(TimeStampedModel):
+    user = models.ForeignKey(User, editable=False)
+    voto = models.IntegerField()
+
+    class Meta:
+        abstract = True
+
+
+class MarcaEmpresaCreada(EntidadCreadaVoluntario):
     """un modelo para trackear la creacion de marcas
     o empresas por voluntarios"""
-    user = models.ForeignKey(User, editable=False)
     marca = models.ForeignKey(Marca, editable=False, null=True)
     empresa = models.ForeignKey(EmpresaFabricante, editable=False, null=True)
 
 
-class VotoMarcaEmpresaCreada(TimeStampedModel):
-    """un usuario vota el item que creó otro """
-    user = models.ForeignKey(User, editable=False)
+class VotoMarcaEmpresaCreada(VotoVoluntario):
+    u"""un usuario vota el item que creó otro """
     item = models.ForeignKey(MarcaEmpresaCreada, related_name='votos')
-    voto = models.IntegerField()
+
+
+class SucursalCadenaCreada(EntidadCreadaVoluntario):
+    u"""un modelo para trackear la creación de sucursales o cadenas
+    de supermercados por voluntarios.
+
+    """
+    sucursal = models.ForeignKey(Sucursal, editable=False, null=True)
+    cadena = models.ForeignKey(Cadena, editable=False, null=True)
+
+
+class VotoSucursalCadenaCreada(VotoVoluntario):
+    u"""un usuario vota el item que creó otro """
+    item = models.ForeignKey(SucursalCadenaCreada, related_name='votos')

--- a/preciosa/voluntarios/urls.py
+++ b/preciosa/voluntarios/urls.py
@@ -10,4 +10,8 @@ urlpatterns = patterns("preciosa.voluntarios.views",
     url(r"^marca/autocomplete/nombre/$", 'autocomplete_nombre_marca',
         name='autocomplete_nombre_marca'),
     url(r"^marca/voto/(?P<pk>\d+)/$", 'voto_item', name='voto_item'),
+    url(r"^sucursal/$", 'alta_cadena_sucursal', name='alta_cadena_sucursal'),
+    url(r"^sucursal/autocomplete/nombre/$", 'autocomplete_nombre_sucursal',
+        name='autocomplete_nombre_sucursal'),
+    url(r"^sucursal/voto/(?P<pk>\d+)/$", 'voto_item', name='voto_item'),
 )


### PR DESCRIPTION
Agregué la vista para los form de cadenas y sucursales usando class based views. 
Modifiqué el método voto_item para que sea más genérico.
Añadí los modelos para trackear la creación de cadenas y sucursales y sus votos. Hay una migración.
Le añadí los verbose_name{,_plural} a los modelos de la app precios.
Pasé el mixin CleanNombreMixin a mixins.py y añadí un mixin para las vistas que requieran autenticación. Le hice unos pequeños cambios a CleanNombreMixin para reutilizarlo.
