### PR TITLE
Arregle el local_settings para que funcionen los test

### DIFF
--- a/preciosa/local_settings.py.template
+++ b/preciosa/local_settings.py.template
@@ -36,4 +36,4 @@ THUMBNAIL_BASEDIR = 'thumbs'
 GOOGLE_ANALYTICS_PROPERTY_ID = 'UA-123456-1'
 
 NOSE_ARGS = ['-s', '--nologcapture', '--nocapture',
-             '--with-progressive', '--with-id', '--logging-clear-handlers']
+             '--with-id', '--logging-clear-handlers']


### PR DESCRIPTION
El Local Settings tenia una opción que rompía la corrida de test en el server de vagrant. La borre. Ahora después de hacer vagrant up se puede hacer python manage.py test
