### PR TITLE
Habilite las migraciones en travis 

### DIFF
--- a/preciosa/settings.py
+++ b/preciosa/settings.py
@@ -336,7 +336,7 @@ GOOGLE_ANALYTICS_PROPERTY_ID = 'UA-123456-1'
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 NOSE_ARGS = ['-s', '--nologcapture', '--nocapture',
              '--with-id', '--logging-clear-handlers']
-SOUTH_TESTS_MIGRATE = False # To disable migrations and use syncdb instead
+SOUTH_TESTS_MIGRATE = True # To disable migrations and use syncdb instead
 SKIP_SOUTH_TESTS = True # To disable South's own unit tests
 
 


### PR DESCRIPTION
La idea es habilitar las migraciones en travis para que se mantenga funcionando el Build y si se rompe enterarnos.
