### PR TITLE
fix confirmation email translation

### DIFF
--- a/preciosa/accounts/forms.py
+++ b/preciosa/accounts/forms.py
@@ -1,9 +1,11 @@
 from django import forms
 
+
 import account.forms
 
 
 class SignupForm(account.forms.SignupForm):
     subscribe_to_newsletter = forms.BooleanField(
+    	label="Suscribirse al boletin",
         required=False
     )

--- a/preciosa/templates/account/email/email_confirmation_message.txt
+++ b/preciosa/templates/account/email/email_confirmation_message.txt
@@ -1,0 +1,7 @@
+{% load i18n account_tags %}
+
+Un usuario en {{ current_site.name }} ha creado una cuenta usando esta dirección de correo electrónico.
+
+Para confirmar esta dirección de correo electrónico, vaya a {{ activate_url }}
+
+Si no desea registrarse en este sitio, puede ignorar este mensaje.

--- a/preciosa/urls.py
+++ b/preciosa/urls.py
@@ -18,7 +18,8 @@ urlpatterns = patterns("",
     url(r'^api/v1/', include("preciosa.api.urls")),  # noqa
     url(r'^api/auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r"^admin/", include(admin.site.urls)),
-    url(r"^account/signup/$", SignupView.as_view()),
+    url(r"^account/signup/$", SignupView.as_view(
+        template_name_email_confirmation_sent='account/email/template_name_email_confirmation_sent')),
     url(r"^account/", include("account.urls")),
     url(r'^newsletter/', include('newsletter.urls')),
     url(r'^feedback/', include('feedback.urls')),


### PR DESCRIPTION
hice un override del template preciosa/templates/account/email/email_confirmation_message.txt antes lo tomaba de la app "pinax-theme-bootstrap-account" pero no lo estaba traduciendo. ademas arregle la traducción del check para suscribirse al newsletter al registrarse.
